### PR TITLE
Update 'When' type for components.

### DIFF
--- a/Alexa.NET.APL/APLComponent.cs
+++ b/Alexa.NET.APL/APLComponent.cs
@@ -28,7 +28,7 @@ namespace Alexa.NET.Response.APL
         }
 
         [JsonProperty("when", NullValueHandling = NullValueHandling.Ignore)]
-        public APLValue<bool> When { get; set; }
+        public APLValue<bool?> When { get; set; }
 
         [JsonProperty("style",NullValueHandling = NullValueHandling.Ignore)]
         public APLValue<string> Style { get; set; }

--- a/Alexa.NET.APL/APLComponent.cs
+++ b/Alexa.NET.APL/APLComponent.cs
@@ -28,7 +28,7 @@ namespace Alexa.NET.Response.APL
         }
 
         [JsonProperty("when", NullValueHandling = NullValueHandling.Ignore)]
-        public APLValue<string> When { get; set; }
+        public APLValue<bool> When { get; set; }
 
         [JsonProperty("style",NullValueHandling = NullValueHandling.Ignore)]
         public APLValue<string> Style { get; set; }


### PR DESCRIPTION
"When" is a boolean value, so it must be a APLValue < bool > for the serialization. If you use a string, it does not interprete it correctly when rendering.

![image](https://user-images.githubusercontent.com/24243459/61177163-bb8df700-a5ce-11e9-885c-0739ce25ee0c.png)
