### PR TITLE
APLGradient inputRange should be an array

### DIFF
--- a/Alexa.NET.APL/APLGradient.cs
+++ b/Alexa.NET.APL/APLGradient.cs
@@ -20,6 +20,6 @@ namespace Alexa.NET.APL
         public APLValue<string[]> ColorRange { get; set; }
 
         [JsonProperty("inputRange",NullValueHandling = NullValueHandling.Ignore)]
-        public APLValue<double?> InputRange { get; set; }
+        public APLValue<double[]> InputRange { get; set; }
     }
 }


### PR DESCRIPTION
Hello,

According to the document, `inputRange` should be an array of `double`.
https://developer.amazon.com/docs/alexa/alexa-presentation-language/apl-data-types.html#gradient