### PR TITLE
Added touchForward proerty

### DIFF
--- a/Alexa.NET.APL/Components/AlexaTextListItem.cs
+++ b/Alexa.NET.APL/Components/AlexaTextListItem.cs
@@ -16,5 +16,8 @@ namespace Alexa.NET.APL.Components
 
         [JsonProperty("tertiaryTextPosition",NullValueHandling = NullValueHandling.Ignore)]
         public APLValue<string> TertiaryTextPosition { get; set; }
+        
+        [JsonProperty("touchForward", NullValueHandling = NullValueHandling.Ignore)]
+        public APLValue<bool?> TouchForward { get; set; }
     }
 }


### PR DESCRIPTION
The AlexaTextListItem has a property `touchForward` that was missing from the library. This adds that field.